### PR TITLE
Starter slider min value and step to 0.25

### DIFF
--- a/src/routes/al2/settings.svelte
+++ b/src/routes/al2/settings.svelte
@@ -24,7 +24,7 @@
           </Tooltip.Root>
           <span class="w-16">{$settings[machine][0].toFixed(1)}s</span>
           {#if machine.includes('starter')}
-          <Slider max={5} min={0.5} step={0.5} bind:value={$settings[machine]} />
+          <Slider max={5} min={0.25} step={0.25} bind:value={$settings[machine]} /> 
           {:else}
           <Slider max={5} min={1} bind:value={$settings[machine]} />
           {/if}


### PR DESCRIPTION
Haven't worked with Svelte much, is there a simple way to make the slider take only specific values (i.e. in this case, only 0.25, 0.5, 0.75, then 1, 2, 3, 4, 5 only)?